### PR TITLE
feat: Add Pre-Warmed Engine (Fast Launch) support for webOS

### DIFF
--- a/lib/commands/create.dart
+++ b/lib/commands/create.dart
@@ -29,7 +29,13 @@ const _kAvailablePlatforms = <String>[
 ];
 
 class WebosCreateCommand extends CreateCommand {
-  WebosCreateCommand({super.verboseHelp});
+  WebosCreateCommand({super.verboseHelp}) {
+    argParser.addFlag(
+      'fast-launch',
+      help: 'Enable Pre-Warmed engine fast launch on webOS.',
+      defaultsTo: false,
+    );
+  }
 
   @override
   void addPlatformsOptions({String? customHelp}) {
@@ -67,6 +73,7 @@ class WebosCreateCommand extends CreateCommand {
     // (the platforms option defaults to a list that already includes webos).
     context['webosAppId'] =
         (context['projectName'] as String? ?? '').replaceAll('_', '-');
+    context['keepAlive'] = boolArg('fast-launch');
     if (argResults!.wasParsed('platforms')) {
       if (_webOSContains()) {
         context['webos'] = true;
@@ -108,6 +115,7 @@ class WebosCreateCommand extends CreateCommand {
     // (the platforms option defaults to a list that already includes webos).
     context['webosAppId'] =
         (context['projectName'] as String? ?? '').replaceAll('_', '-');
+    context['keepAlive'] = boolArg('fast-launch');
     if (argResults!.wasParsed('platforms')) {
       if (_webOSContains()) {
         context['webos'] = true;

--- a/lib/commands/run.dart
+++ b/lib/commands/run.dart
@@ -10,10 +10,23 @@ import 'package:flutter_tools/src/commands/run.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 
 import '../webos_cache.dart';
+import '../webos_device.dart';
 import '../webos_plugins.dart';
 
 class WebosRunCommand extends RunCommand with WebosExtension, WebosRequiredArtifacts {
-  WebosRunCommand({super.verboseHelp});
+  WebosRunCommand({super.verboseHelp}) {
+    argParser.addFlag(
+      'pre-warm',
+      help: 'Launch the webOS app invisibly in the background to pre-warm the Flutter engine.',
+      defaultsTo: false,
+    );
+  }
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    WebosDevice.preWarmRequested = boolArg('pre-warm');
+    return super.runCommand();
+  }
 
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{

--- a/lib/webos_device.dart
+++ b/lib/webos_device.dart
@@ -63,6 +63,8 @@ class WebosDevice extends Device {
         deviceName: _config.label, deviceId: _config.id, aresCli: _aresCli, logger: _logger);
   }
 
+  static bool preWarmRequested = false;
+
   final WebosRemoteDeviceConfig _config;
   final bool _desktop;
   final String _backendType;
@@ -548,7 +550,11 @@ class WebosDevice extends Device {
     final engineSwitches = <String, Object>{};
 
     if (debuggingOptions == null) {
-      return jsonEncode(<String, Object>{'engine-switches': engineSwitches});
+      final launchParams = <String, Object>{'engine-switches': engineSwitches};
+      if (preWarmRequested) {
+        launchParams['background'] = true;
+      }
+      return jsonEncode(launchParams);
     }
 
     engineSwitches['enable-dart-profiling'] = true;
@@ -620,7 +626,11 @@ class WebosDevice extends Device {
       engineSwitches['enable-flutter-gpu'] = true;
     }
 
-    return jsonEncode(<String, Object>{'engine-switches': engineSwitches});
+    final launchParams = <String, Object>{'engine-switches': engineSwitches};
+    if (preWarmRequested) {
+      launchParams['background'] = true;
+    }
+    return jsonEncode(launchParams);
   }
 
   /// Source: `DesktopDevice._computeEnvironment` in `desktop_device.dart`

--- a/templates/app/meta/appinfo.json.tmpl
+++ b/templates/app/meta/appinfo.json.tmpl
@@ -16,7 +16,9 @@
     "noSplashOnLaunch":true,
     "spinnerOnLaunch": false,
     "transparent":false,
-    "uiRevision":2,
+    "uiRevision": 2,
+    "keepAlive": {{keepAlive}},
+    "bgImage": "icon.png",
     "requiredACG": [
     ]
 }

--- a/test/fast_launch_stress_test.dart
+++ b/test/fast_launch_stress_test.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> main() async {
+  print('Starting ultimate stress test for --fast-launch template rendering...');
+  
+  final tmpDir = Directory.systemTemp.createTempSync('webos_stress_test');
+  print('Working directory: ${tmpDir.path}');
+
+  const int numProjects = 15;
+  final List<Future<void>> tasks = [];
+
+  for (int i = 0; i < numProjects; i++) {
+    tasks.add(_createProject(tmpDir, 'stress_app_$i'));
+  }
+
+  final startTime = DateTime.now();
+  
+  // Run all creations concurrently to test for race conditions/file locks
+  try {
+    await Future.wait(tasks);
+  } catch (e) {
+    print('❌ Stress test failed with exception: $e');
+    exit(1);
+  }
+
+  final duration = DateTime.now().difference(startTime);
+  
+  print('✅ Successfully created $numProjects projects concurrently in ${duration.inMilliseconds}ms');
+
+  // Verify all projects have the correct keepAlive flag
+  int verifiedCount = 0;
+  for (int i = 0; i < numProjects; i++) {
+    final appInfoFile = File('${tmpDir.path}/stress_app_$i/webos/meta/appinfo.json');
+    if (!appInfoFile.existsSync()) {
+      print('❌ Missing appinfo.json in stress_app_$i');
+      exit(1);
+    }
+    
+    final content = appInfoFile.readAsStringSync();
+    final json = jsonDecode(content);
+    
+    if (json['keepAlive'] != true) {
+      print('❌ keepAlive is not true in stress_app_$i: $content');
+      exit(1);
+    }
+    
+    if (json['bgImage'] != 'icon.png') {
+      print('❌ bgImage is missing or incorrect in stress_app_$i: $content');
+      exit(1);
+    }
+    
+    verifiedCount++;
+  }
+
+  print('✅ All $verifiedCount projects verified to have perfect Fast Launch configurations.');
+  
+  // Cleanup
+  tmpDir.deleteSync(recursive: true);
+  print('🧹 Cleanup complete. STRESS TEST PASSED.');
+}
+
+Future<void> _createProject(Directory tmpDir, String name) async {
+  final process = await Process.run(
+    'dart',
+    [
+      'bin/flutter_webos.dart',
+      'create',
+      '--platforms',
+      'webos',
+      '--fast-launch',
+      '${tmpDir.path}/$name'
+    ],
+    workingDirectory: Directory.current.path,
+  );
+
+  if (process.exitCode != 0) {
+    throw Exception('Failed to create project $name:\nSTDOUT: ${process.stdout}\nSTDERR: ${process.stderr}');
+  }
+}


### PR DESCRIPTION
- Adds `--fast-launch` flag to `flutter-webos create` to generate apps with `keepAlive: true` in appinfo.json.
- Adds `--pre-warm` flag to `flutter-webos run` which injects `"background": true` into the Ares/Luna launch parameters, allowing the Flutter engine to boot invisibly in the background.
- This massively reduces app launch time for users by parking the Dart VM in memory before the UI is presented.